### PR TITLE
Add Nest layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ In general, the Pyoneer API tries to adhere to the TensorFlow 2.0 API.
 - `pynr.layers.Swish`
 - `pynr.layers.OneHotEncoder`
 - `pynr.layers.AngleEncoder`
+- `pynr.layers.Nest`
 
 ### Tensor Manipulation ([`pynr.manip`](pyoneer/manip))
 

--- a/pyoneer/layers/__init__.py
+++ b/pyoneer/layers/__init__.py
@@ -2,6 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from pyoneer.layers.layers_impl import Swish, OneHotEncoder, AngleEncoder
+from pyoneer.layers.layers_impl import Swish, OneHotEncoder, AngleEncoder, Nest
 
-__all__ = ["Swish", "OneHotEncoder", "AngleEncoder"]
+__all__ = ["Swish", "OneHotEncoder", "AngleEncoder", "Nest"]

--- a/pyoneer/layers/layers_test.py
+++ b/pyoneer/layers/layers_test.py
@@ -5,7 +5,8 @@ from __future__ import print_function
 import math
 import tensorflow as tf
 
-from pyoneer.layers.layers_impl import Swish, OneHotEncoder, AngleEncoder
+from pyoneer.math import angle_ops
+from pyoneer.layers.layers_impl import Swish, OneHotEncoder, AngleEncoder, Nest
 
 
 class LayersTest(tf.test.TestCase):
@@ -35,6 +36,42 @@ class LayersTest(tf.test.TestCase):
         inputs = tf.constant([[180]], dtype=tf.float32)
         outputs = layer(inputs)
         expected = tf.constant([[-1, 0]], dtype=tf.float32)
+        self.assertAllClose(outputs, expected)
+
+    def test_nest_features(self):
+        nest_layer = Nest(
+            {
+                "category": OneHotEncoder(depth=3),
+                "angle": AngleEncoder(degrees=True),
+                "nested": {
+                    "category": OneHotEncoder(depth=3),
+                    "angle": AngleEncoder(degrees=True),
+                },
+            }
+        )
+        features = {
+            "category": tf.constant([1]),
+            "angle": tf.constant([[-45.0]]),
+            "nested": {"category": tf.constant([2]), "angle": tf.constant([[45.0]])},
+        }
+        outputs = nest_layer(features)
+        expected = tf.stack(
+            [
+                [
+                    tf.math.cos(angle_ops.to_radians(-45.0)),
+                    tf.math.sin(angle_ops.to_radians(-45.0)),
+                    0.0,
+                    1.0,
+                    0.0,
+                    tf.math.cos(angle_ops.to_radians(+45.0)),
+                    tf.math.sin(angle_ops.to_radians(+45.0)),
+                    0.0,
+                    0.0,
+                    1.0,
+                ]
+            ],
+            axis=0,
+        )
         self.assertAllClose(outputs, expected)
 
 


### PR DESCRIPTION
The next layer maps an arbitrarily nested structure of layers to an equivalent structure of input features using the `tf.nest` API.

This is a more flexible API than our original `DictFeaturizer` which only supported dictionaries and a more intuitive API (to me, at least) than `tf.feature_columns`. In addition, `tf.feature_columns` appears to be primarily intended for estimators.

Address #35

For example:

    nest_layer = pynr.layers.Nest({
        "category": pynr.layers.OneHotEncoder(depth=3),
        "angle": pynr.layers.AngleEncoder(degrees=True),
        "nested": {
            "category": pynr.layers.OneHotEncoder(depth=3),
            "angle": pynr.layers.AngleEncoder(degrees=True),
        }
    })

    features = {
        "category": tf.constant([1]),
        "angle": tf.constant([[-45.0]]),
        "nested": {
            "category": tf.constant([2]),
            "angle": tf.constant([[+45.0]]),
        }
    }

    outputs = nest_layer(features)  # shape: [1, (2 + 3) * 2]